### PR TITLE
Added EnaSupport=True for Elastic Network Adapter

### DIFF
--- a/SnapAndDelete.py
+++ b/SnapAndDelete.py
@@ -96,7 +96,7 @@ def lambda_handler(object, context):
             DryRun=False, 
             VirtualizationType='hvm', 
             EnaSupport=True #Supported instance types: current generation instance type, other than C4, D2, M4 instances smaller than m4.16xlarge, or T2. https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/enhanced-networking-ena.html
-            #Remove # in froont of "SriovNetSupport='simple'" to use SriovNetSupport, and add a # in front of "EnaSupport=True".
+            #Remove # in front of "SriovNetSupport='simple'" and add a # in front of "EnaSupport=True" to use SriovNetSupport.
             #SriovNetSupport='simple' #Supported instance types: C3, C4, D2, I2, M4 (excluding m4.16xlarge), and R3. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sriov-networking.html
         )
         print('Created image {}'.format(ami['ImageId']))

--- a/SnapAndDelete.py
+++ b/SnapAndDelete.py
@@ -95,7 +95,8 @@ def lambda_handler(object, context):
             RootDeviceName='/dev/sda1', 
             DryRun=False, 
             VirtualizationType='hvm', 
-            SriovNetSupport='simple'
+            EnaSupport=True #Supported instance types: current generation instance type, other than C4, D2, M4 instances smaller than m4.16xlarge, or T2. https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/enhanced-networking-ena.html
+            #SriovNetSupport='simple' Supported instance types: C3, C4, D2, I2, M4 (excluding m4.16xlarge), and R3. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sriov-networking.html
         )
         print('Created image {}'.format(ami['ImageId']))
         amis_created.append(ami['ImageId'])

--- a/SnapAndDelete.py
+++ b/SnapAndDelete.py
@@ -96,7 +96,8 @@ def lambda_handler(object, context):
             DryRun=False, 
             VirtualizationType='hvm', 
             EnaSupport=True #Supported instance types: current generation instance type, other than C4, D2, M4 instances smaller than m4.16xlarge, or T2. https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/enhanced-networking-ena.html
-            #SriovNetSupport='simple' Supported instance types: C3, C4, D2, I2, M4 (excluding m4.16xlarge), and R3. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sriov-networking.html
+            #Remove # in froont of "SriovNetSupport='simple'" to use SriovNetSupport, and add a # in front of "EnaSupport=True".
+            #SriovNetSupport='simple' #Supported instance types: C3, C4, D2, I2, M4 (excluding m4.16xlarge), and R3. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sriov-networking.html
         )
         print('Created image {}'.format(ami['ImageId']))
         amis_created.append(ami['ImageId'])


### PR DESCRIPTION
I kept getting this error every time I tried to launch an instance from the automatic AMI. "An error occurred (InvalidParameterCombination) when calling the RunInstances operation: Enhanced networking with the Elastic Network Adapter (ENA) is required for the 'g4dn.xlarge' instance type. Ensure that you are using an AMI that is enabled for ENA."

Since g4dn.xlarge or greater requires Elastic Network Adapter enhanced networking we need to use ```EnaSupport=True``` instead of ```SriovNetSupport='simple'```.

https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/enhanced-networking.html

```EnaSupport=True``` Supported instance types: current generation instance type, other than C4, D2, M4 instances smaller than m4.16xlarge, or T2. https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/enhanced-networking-ena.html

```SriovNetSupport='simple' ``` Supported instance types: C3, C4, D2, I2, M4 (excluding m4.16xlarge), and R3. https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/sriov-networking.html